### PR TITLE
Use custom target dir for `cargo install`

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libusb-1.0-0-dev pkg-config
     - name: Install probe-run / flip-link
-      run: cargo install probe-run flip-link
+      run: cargo install probe-run flip-link --target-dir target
     - name: Run tests on hardware
       working-directory: testsuite
       run: cargo test


### PR DESCRIPTION
By default it uses `/tmp`, which is in RAM only, and the HIL runner doesn't have much RAM.

bors r+