### PR TITLE
Add transmit function that returns the mailbox number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* Add transmit function that returns the mailbox number ([#25]).
+* Add transmit function that returns the mailbox number, and transmit abort function ([#25]).
 
 [#25]: https://github.com/stm32-rs/bxcan/pull/25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-No changes.
+### New Features
+
+* Add transmit function that returns the mailbox number ([#25]).
+
+[#25]: https://github.com/stm32-rs/bxcan/pull/25
 
 ## [0.5.0 - 2021-03-15](https://github.com/stm32-rs/bxcan/releases/tag/v0.5.0)
 

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -3,7 +3,7 @@
 macro_rules! doc {
     ($e:expr) => {
         #[doc = $e]
-        extern {}
+        extern "C" {}
     };
 }
 


### PR DESCRIPTION
# Motivation

I am developing an implementation of the [UAVCAN protocol](https://uavcan.org) that uses this bxCAN driver. Each outgoing frame has a transmit deadline. A frame must be discarded if it has not been transmitted by its deadline.

If a frame is placed in a transmit mailbox and later displaced by a higher-priority frame before being transmitted, the software will keep the displaced frame to transmit later. The problem is that there is currently no way to know the deadline of the displaced frame.

# Proposed changes

I am proposing to make the smallest possible change that allows this use case to work. This pull request adds a `transmit_and_get_mailbox` function to the `Can` and `Tx` structs. This function is like `transmit`, but it returns the number of the mailbox that was accessed.

This will allow other code to keep track of the deadline (or other metadata) for the frame in each mailbox, even when frames get displaced.