### PR TITLE
Fix definition of bits in Interrupt enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@
 
 * Add transmit function that returns the mailbox number, and transmit abort function ([#25]).
 
+### Fixes
+
+* The `Can::enable_interrupt` and `Can::disable_interrupt` functions now manipulate the correct bits in the interrupt
+  enable register ([#28]).
+
 [#25]: https://github.com/stm32-rs/bxcan/pull/25
+[#28]: https://github.com/stm32-rs/bxcan/pull/28
 
 ## [0.5.0 - 2021-03-15](https://github.com/stm32-rs/bxcan/releases/tag/v0.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 ### Fixes
 
 * The `Can::enable_interrupt` and `Can::disable_interrupt` functions now manipulate the correct bits in the interrupt
-  enable register ([#28]).
+  enable register ([#29]).
 
 [#25]: https://github.com/stm32-rs/bxcan/pull/25
-[#28]: https://github.com/stm32-rs/bxcan/pull/28
+[#29]: https://github.com/stm32-rs/bxcan/pull/29
 
 ## [0.5.0 - 2021-03-15](https://github.com/stm32-rs/bxcan/releases/tag/v0.5.0)
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -8,16 +8,16 @@ use defmt::Format;
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Format)]
 #[non_exhaustive]
 pub enum Interrupt {
-    Sleep = 17,
-    Wakeup = 16,
-    Error = 15,
-    Fifo1Overrun = 6,
-    Fifo1Full = 5,
-    Fifo1MessagePending = 4,
-    Fifo0Overrun = 3,
-    Fifo0Full = 2,
-    Fifo0MessagePending = 1,
-    TransmitMailboxEmpty = 0,
+    Sleep = 1 << 17,
+    Wakeup = 1 << 16,
+    Error = 1 << 15,
+    Fifo1Overrun = 1 << 6,
+    Fifo1Full = 1 << 5,
+    Fifo1MessagePending = 1 << 4,
+    Fifo0Overrun = 1 << 3,
+    Fifo0Full = 1 << 2,
+    Fifo0MessagePending = 1 << 1,
+    TransmitMailboxEmpty = 1 << 0,
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
# The problem

When using `Can::enable_interrupt` or `Can::disable_interrupt`with the `Interrupt` enum (not the `Interrupts` flags), the incorrect bits in the interrupt enable register are modified.

## Example

The code

```rust
fn read_ier() -> u32 {
    unsafe { core::ptr::read_volatile((0x4000_6400_usize + 0x14_usize) as *const u32) }
}

can.enable_interrupt(bxcan::Interrupt::Fifo0MessagePending);
rprintln!(
    "Interupt enable register set using single interrupt: {:#010x}",
    read_ier()
);
can.disable_interrupts(bxcan::Interrupts::all());
rprintln!("Interupt enable register cleared: {:#010x}", read_ier());
can.enable_interrupts(bxcan::Interrupts::FIFO0_MESSAGE_PENDING);
rprintln!(
    "Interupt enable register set using interrupt flags: {:#010x}",
    read_ier()
);
```
prints
```
Interupt enable register set using single interrupt: 0x00000001
Interupt enable register cleared: 0x00000000
Interupt enable register set using interrupt flags: 0x00000002
```

## Why this happens

The `Can::enable_interrupt` and `Can::disable_interrupt`functions convert the `Interrupt` into a bit flag. However, the `Interrupt` discriminant values are not flags, they are bit positions. In the above example, `Interrupt::Fifo0MessagePending` (defined as 1) gets converted into `Interrupts::TRANSMIT_MAILBOX_EMPTY` (also defined as 1), and the transmit mailbox empty bit gets set in the interrupt enable register.

# The fix

This change simply changes the discriminant values of `Interrupt` so that they have the same values as the corresponding `Interrupts` flags. The modified code correctly enables interrupts in my tests so far.