### PR TITLE
Improve interrupt support and testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,20 @@
 ### New Features
 
 * Add transmit function that returns the mailbox number, and transmit abort function ([#25]).
+* Added more methods to acknowledge interrupts ([#30]).
 
 ### Fixes
 
 * The `Can::enable_interrupt` and `Can::disable_interrupt` functions now manipulate the correct bits in the interrupt
   enable register ([#29]).
 
+### Misc
+
+* Improve documentation of interrupts ([#30]).
+
 [#25]: https://github.com/stm32-rs/bxcan/pull/25
 [#29]: https://github.com/stm32-rs/bxcan/pull/29
+[#30]: https://github.com/stm32-rs/bxcan/pull/30
 
 ## [0.5.0 - 2021-03-15](https://github.com/stm32-rs/bxcan/releases/tag/v0.5.0)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ embedded-can = "0.3"
 
 [profile.test]
 opt-level = "s"
+# FIXME: Turning LTO off makes the testsuite executables 2.5x larger.
+# Turning it on makes `cargo test` on the host take a bit long to build.
 lto = true
 
 # cargo-release configuration

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -4,47 +4,128 @@ use core::ops;
 
 use defmt::Format;
 
+#[allow(unused_imports)] // for intra-doc links only
+use crate::{Can, Rx};
+
 /// bxCAN interrupt sources.
+///
+/// These can be individually enabled and disabled in the bxCAN peripheral. Note that the bxCAN
+/// peripheral only exposes 4 interrupts to the microcontroller:
+///
+/// * TX
+/// * RX FIFO 1
+/// * RX FIFO 2
+/// * SCE (Status Change Error)
+///
+/// This means that some of the interrupts listed here will result in the same interrupt handler
+/// being invoked.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Format)]
 #[non_exhaustive]
 pub enum Interrupt {
-    Sleep = 1 << 17,
-    Wakeup = 1 << 16,
-    Error = 1 << 15,
-    Fifo1Overrun = 1 << 6,
-    Fifo1Full = 1 << 5,
-    Fifo1MessagePending = 1 << 4,
-    Fifo0Overrun = 1 << 3,
-    Fifo0Full = 1 << 2,
-    Fifo0MessagePending = 1 << 1,
+    /// Fires the **TX** interrupt when one of the transmit mailboxes returns to empty state.
+    ///
+    /// This usually happens because its message was either transmitted successfully, or
+    /// transmission was aborted successfully.
+    ///
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_request_completed_flag`] or [`Can::clear_tx_interrupt`].
     TransmitMailboxEmpty = 1 << 0,
+
+    /// Fires the **RX FIFO 0** interrupt when FIFO 0 holds a message.
+    ///
+    /// The interrupt handler must clear the interrupt condition by receiving all messages from the
+    /// FIFO by calling [`Can::receive`] or [`Rx::receive`].
+    Fifo0MessagePending = 1 << 1,
+
+    /// Fires the **RX FIFO 0** interrupt when FIFO 0 holds 3 incoming messages.
+    ///
+    /// The interrupt handler must clear the interrupt condition by receiving at least one message
+    /// from the FIFO (making it no longer "full"). This can be done by calling [`Can::receive`] or
+    /// [`Rx::receive`].
+    Fifo0Full = 1 << 2,
+
+    /// Fires the **RX FIFO 0** interrupt when FIFO 0 drops an incoming message.
+    ///
+    /// The interrupt handler must clear the interrupt condition by calling [`Can::receive`] or
+    /// [`Rx::receive`] (which will return an error).
+    Fifo0Overrun = 1 << 3,
+
+    /// Fires the **RX FIFO 1** interrupt when FIFO 1 holds a message.
+    ///
+    /// Behavior is otherwise identical to [`Self::Fifo0MessagePending`].
+    Fifo1MessagePending = 1 << 4,
+
+    /// Fires the **RX FIFO 1** interrupt when FIFO 1 holds 3 incoming messages.
+    ///
+    /// Behavior is otherwise identical to [`Self::Fifo0Full`].
+    Fifo1Full = 1 << 5,
+
+    /// Fires the **RX FIFO 1** interrupt when FIFO 1 drops an incoming message.
+    ///
+    /// Behavior is otherwise identical to [`Self::Fifo0Overrun`].
+    Fifo1Overrun = 1 << 6,
+
+    Error = 1 << 15,
+
+    /// Fires the **SCE** interrupt when an incoming CAN frame is detected while the peripheral is
+    /// in sleep mode.
+    ///
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_wakeup_interrupt`].
+    Wakeup = 1 << 16,
+
+    /// Fires the **SCE** interrupt when the peripheral enters sleep mode.
+    ///
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_sleep_interrupt`].
+    Sleep = 1 << 17,
 }
 
 bitflags::bitflags! {
     /// A set of bxCAN interrupts.
     pub struct Interrupts: u32 {
-        const SLEEP = 1 << 17;
-        const WAKEUP = 1 << 16;
-        const ERROR = 1 << 15;
-        const FIFO1_OVERRUN = 1 << 6;
-        const FIFO1_FULL = 1 << 5;
-        const FIFO1_MESSAGE_PENDING = 1 << 4;
-        const FIFO0_OVERRUN = 1 << 3;
-        const FIFO0_FULL = 1 << 2;
-        const FIFO0_MESSAGE_PENDING = 1 << 1;
         const TRANSMIT_MAILBOX_EMPTY = 1 << 0;
+        const FIFO0_MESSAGE_PENDING = 1 << 1;
+        const FIFO0_FULL = 1 << 2;
+        const FIFO0_OVERRUN = 1 << 3;
+        const FIFO1_MESSAGE_PENDING = 1 << 4;
+        const FIFO1_FULL = 1 << 5;
+        const FIFO1_OVERRUN = 1 << 6;
+        const ERROR = 1 << 15;
+        const WAKEUP = 1 << 16;
+        const SLEEP = 1 << 17;
     }
 }
 
 impl From<Interrupt> for Interrupts {
+    #[inline]
     fn from(i: Interrupt) -> Self {
         Self::from_bits_truncate(i as u32)
     }
 }
 
-/// Adds an interrupts to the interrupt set.
+/// Adds an interrupt to the interrupt set.
 impl ops::BitOrAssign<Interrupt> for Interrupts {
+    #[inline]
     fn bitor_assign(&mut self, rhs: Interrupt) {
         *self |= Self::from(rhs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interrupt_flags() {
+        assert_eq!(Interrupts::from(Interrupt::Sleep), Interrupts::SLEEP);
+        assert_eq!(
+            Interrupts::from(Interrupt::TransmitMailboxEmpty),
+            Interrupts::TRANSMIT_MAILBOX_EMPTY
+        );
+
+        let mut ints = Interrupts::FIFO0_FULL;
+        ints |= Interrupt::Fifo1Full;
+        assert_eq!(ints, Interrupts::FIFO0_FULL | Interrupts::FIFO1_FULL);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ where
 
     /// Puts the peripheral in a sleep mode to save power.
     ///
-    /// Reception and transmission is disabled.
+    /// While in sleep mode, an incoming CAN frame will trigger [`Interrupt::Wakeup`] if enabled.
     pub fn sleep(&mut self) {
         let can = self.registers();
         can.mcr
@@ -373,6 +373,22 @@ where
         loop {
             let msr = can.msr.read();
             if msr.slak().bit_is_set() && msr.inak().bit_is_clear() {
+                break;
+            }
+        }
+    }
+
+    /// Wakes up from sleep mode.
+    ///
+    /// Note that this will not trigger [`Interrupt::Wakeup`], only reception of an incoming CAN
+    /// frame will cause that interrupt.
+    pub fn wakeup(&mut self) {
+        let can = self.registers();
+        can.mcr
+            .modify(|_, w| w.sleep().clear_bit().inrq().clear_bit());
+        loop {
+            let msr = can.msr.read();
+            if msr.slak().bit_is_clear() && msr.inak().bit_is_clear() {
                 break;
             }
         }
@@ -402,10 +418,48 @@ where
             .modify(|r, w| unsafe { w.bits(r.bits() & !interrupts.bits()) })
     }
 
+    /// Clears the pending flag of [`Interrupt::Sleep`].
+    pub fn clear_sleep_interrupt(&mut self) {
+        let can = self.registers();
+        can.msr.write(|w| w.slaki().set_bit());
+    }
+
     /// Clears the pending flag of [`Interrupt::Wakeup`].
     pub fn clear_wakeup_interrupt(&mut self) {
         let can = self.registers();
         can.msr.write(|w| w.wkui().set_bit());
+    }
+
+    /// Clears the "Request Completed" (RQCP) flag of a transmit mailbox.
+    ///
+    /// Returns the [`Mailbox`] whose flag was cleared. If no mailbox has the flag set, returns
+    /// `None`.
+    ///
+    /// Once this function returns `None`, a pending [`Interrupt::TransmitMailboxEmpty`] is
+    /// considered acknowledged.
+    pub fn clear_request_completed_flag(&mut self) -> Option<Mailbox> {
+        let can = self.registers();
+        let tsr = can.tsr.read();
+        if tsr.rqcp0().bit_is_set() {
+            can.tsr.modify(|_, w| w.rqcp0().set_bit());
+            Some(Mailbox::Mailbox0)
+        } else if tsr.rqcp1().bit_is_set() {
+            can.tsr.modify(|_, w| w.rqcp1().set_bit());
+            Some(Mailbox::Mailbox1)
+        } else if tsr.rqcp2().bit_is_set() {
+            can.tsr.modify(|_, w| w.rqcp2().set_bit());
+            Some(Mailbox::Mailbox2)
+        } else {
+            None
+        }
+    }
+
+    /// Clears a pending TX interrupt ([`Interrupt::TransmitMailboxEmpty`]).
+    ///
+    /// This does not return the mailboxes that have finished tranmission. If you need that
+    /// information, call [`Can::clear_request_completed_flag`] instead.
+    pub fn clear_tx_interrupt(&mut self) {
+        while self.clear_request_completed_flag().is_some() {}
     }
 
     /// Puts a CAN frame in a free transmit mailbox for transmission on the bus.
@@ -800,7 +854,7 @@ where
 }
 
 /// The three transmit mailboxes
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Format)]
 pub enum Mailbox {
     /// Transmit mailbox 0
     Mailbox0 = 0,

--- a/testsuite/.cargo/config.toml
+++ b/testsuite/.cargo/config.toml
@@ -12,8 +12,8 @@ rustflags = [
 [build]
 # (`thumbv6m-*` is compatible with all ARM Cortex-M chips but using the right
 # target improves performance)
-target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+target = "thumbv7m-none-eabi"    # Cortex-M3
 # target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
 # target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -13,6 +13,10 @@ test = false
 name = "integration"
 harness = false
 
+[[test]]
+name = "interrupts"
+harness = false
+
 [dependencies]
 bxcan = { path = ".." }
 cortex-m = "0.6.3"
@@ -24,8 +28,9 @@ panic-probe = "0.2.0"
 #panic-probe = { version = "0.2.0", features = ["print-defmt"] }
 # NB: We use F107 here, which seems to share its SVD file with the F105. The difference is that the
 # 107 has Ethernet, but we don't use that.
-stm32f1 = { version = "0.12.1", features = ["stm32f107"] }
+stm32f1 = { version = "0.12.1", features = ["stm32f107", "rt"] }
 nb = "1.0.0"
+irq = "0.2.3"
 
 [features]
 # set logging levels here

--- a/testsuite/src/interrupt.rs
+++ b/testsuite/src/interrupt.rs
@@ -1,0 +1,41 @@
+use core::cell::RefCell;
+
+use crate::pac::interrupt;
+
+irq::scoped_interrupts! {
+    #[allow(non_camel_case_types)]
+    pub enum Interrupt {
+        USB_HP_CAN_TX,
+        USB_LP_CAN_RX0,
+        CAN_RX1,
+        CAN_SCE,
+        CAN2_TX,
+        CAN2_RX0,
+        CAN2_RX1,
+        CAN2_SCE,
+    }
+
+    use #[interrupt];
+}
+
+pub use Interrupt::CAN_RX1 as CAN1_RX1;
+pub use Interrupt::CAN_SCE as CAN1_SCE;
+pub use Interrupt::USB_HP_CAN_TX as CAN1_TX;
+pub use Interrupt::USB_LP_CAN_RX0 as CAN1_RX0;
+pub use Interrupt::{CAN2_RX0, CAN2_RX1, CAN2_SCE, CAN2_TX};
+
+pub struct Mutex<T> {
+    object: cortex_m::interrupt::Mutex<RefCell<T>>,
+}
+
+impl<T> Mutex<T> {
+    pub const fn new(object: T) -> Self {
+        Self {
+            object: cortex_m::interrupt::Mutex::new(RefCell::new(object)),
+        }
+    }
+
+    pub fn lock<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        cortex_m::interrupt::free(|cs| f(&mut *self.object.borrow(cs).borrow_mut()))
+    }
+}

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -10,7 +10,7 @@
 use defmt_rtt as _;
 use panic_probe as _;
 
-use bxcan::{FilterOwner, Instance, MasterInstance};
+use bxcan::{Can, FilterOwner, Frame, Instance, MasterInstance};
 
 pub use stm32f1::stm32f107 as pac;
 
@@ -37,7 +37,7 @@ unsafe impl Instance for CAN2 {
     const REGISTERS: *mut bxcan::RegisterBlock = 0x4000_6800 as *mut _;
 }
 
-pub fn init(p: pac::Peripherals) -> (CAN1, CAN2) {
+fn init(p: pac::Peripherals) -> (CAN1, CAN2) {
     p.RCC
         .apb1enr
         .modify(|_, w| w.can1en().enabled().can2en().enabled());
@@ -67,4 +67,72 @@ pub fn init(p: pac::Peripherals) -> (CAN1, CAN2) {
     let _ = (p.CAN1, p.CAN2);
 
     (CAN1 { _private: () }, CAN2 { _private: () })
+}
+
+pub struct State {
+    pub can1: Can<CAN1>,
+    pub can2: Can<CAN2>,
+}
+
+impl State {
+    pub fn init() -> Self {
+        let periph = defmt::unwrap!(pac::Peripherals::take());
+        let (can1, can2) = init(periph);
+        let mut can1 = Can::new(can1);
+        let can2 = Can::new(can2);
+        can1.modify_filters().clear();
+
+        let mut state = Self { can1, can2 };
+        state.go_fast();
+        state
+    }
+
+    /// Configures the slowest possible speed.
+    ///
+    /// This is useful for testing recovery when the mailboxes are full.
+    pub fn go_slow(&mut self) {
+        self.can1
+            .modify_config()
+            .set_loopback(true)
+            .set_silent(true)
+            .set_bit_timing(0x007f_03ff);
+        self.can2
+            .modify_config()
+            .set_loopback(true)
+            .set_silent(true)
+            .set_bit_timing(0x007f_03ff);
+        nb::block!(self.can1.enable()).unwrap();
+    }
+
+    /// Configures the default (fast) speed.
+    pub fn go_fast(&mut self) {
+        self.can1
+            .modify_config()
+            .set_loopback(true)
+            .set_silent(true)
+            .set_bit_timing(0x00050000);
+        self.can2
+            .modify_config()
+            .set_loopback(true)
+            .set_silent(true)
+            .set_bit_timing(0x00050000);
+        nb::block!(self.can1.enable()).unwrap();
+    }
+
+    pub fn roundtrip_frame(&mut self, frame: &Frame) -> bool {
+        nb::block!(self.can1.transmit(frame)).unwrap();
+        defmt::assert!(!self.can1.is_transmitter_idle());
+
+        // Wait until the transmission has completed.
+        while !self.can1.is_transmitter_idle() {}
+
+        match self.can1.receive() {
+            Ok(received) => {
+                defmt::assert_eq!(received, *frame);
+                true
+            }
+            Err(nb::Error::WouldBlock) => false,
+            Err(nb::Error::Other(e)) => defmt::panic!("{:?}", e),
+        }
+    }
 }

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -7,6 +7,9 @@
 
 #![no_std]
 
+pub mod interrupt;
+
+use cortex_m::peripheral::NVIC;
 use defmt_rtt as _;
 use panic_probe as _;
 
@@ -38,6 +41,20 @@ unsafe impl Instance for CAN2 {
 }
 
 fn init(p: pac::Peripherals) -> (CAN1, CAN2) {
+    // Enable CAN interrupts
+    // Safety: `irq` is safe when all interrupts it manages are enabled.
+    unsafe {
+        NVIC::unmask(pac::Interrupt::USB_HP_CAN_TX);
+        NVIC::unmask(pac::Interrupt::USB_LP_CAN_RX0);
+        NVIC::unmask(pac::Interrupt::CAN_RX1);
+        NVIC::unmask(pac::Interrupt::CAN_SCE);
+        NVIC::unmask(pac::Interrupt::CAN2_TX);
+        NVIC::unmask(pac::Interrupt::CAN2_RX0);
+        NVIC::unmask(pac::Interrupt::CAN2_RX1);
+        NVIC::unmask(pac::Interrupt::CAN2_SCE);
+    }
+
+    // Initialize CAN peripherals
     p.RCC
         .apb1enr
         .modify(|_, w| w.can1en().enabled().can2en().enabled());
@@ -117,6 +134,7 @@ impl State {
             .set_silent(true)
             .set_bit_timing(0x00050000);
         nb::block!(self.can1.enable()).unwrap();
+        nb::block!(self.can2.enable()).unwrap();
     }
 
     pub fn roundtrip_frame(&mut self, frame: &Frame) -> bool {

--- a/testsuite/tests/integration.rs
+++ b/testsuite/tests/integration.rs
@@ -1,15 +1,13 @@
 #![no_std]
 #![no_main]
 
-use nb::block;
-use testsuite::{self, State};
-
 #[defmt_test::tests]
 mod tests {
     use bxcan::filter::{ListEntry32, Mask16, Mask32};
     use bxcan::{ExtendedId, Frame, StandardId};
 
-    use super::*;
+    use nb::block;
+    use testsuite::State;
 
     #[init]
     fn init() -> State {

--- a/testsuite/tests/interrupts.rs
+++ b/testsuite/tests/interrupts.rs
@@ -1,0 +1,264 @@
+#![no_std]
+#![no_main]
+
+#[defmt_test::tests]
+mod tests {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use bxcan::{filter::Mask32, Interrupts, Mailbox, StandardId};
+    use bxcan::{Frame, Interrupt};
+
+    use irq::handler;
+    use nb::block;
+    use testsuite::{
+        interrupt::{self, Mutex},
+        State,
+    };
+
+    #[init]
+    fn init() -> State {
+        let mut state = State::init();
+
+        // Accept all messages.
+        state
+            .can1
+            .modify_filters()
+            .set_split(1)
+            .clear()
+            .enable_bank(0, Mask32::accept_all())
+            .slave_filters()
+            .clear()
+            .enable_bank(1, Mask32::accept_all());
+
+        state
+    }
+
+    #[test]
+    fn tx_interrupt(state: &mut State) {
+        state.can1.enable_interrupt(Interrupt::TransmitMailboxEmpty);
+
+        let m = Mutex::new(&mut *state);
+        let tx_fired = AtomicBool::new(false);
+        handler!(
+            can1_tx = || {
+                defmt::debug!("CAN1 TX interrupt");
+                defmt::assert_eq!(
+                    m.lock(|state| state.can1.clear_request_completed_flag()),
+                    Some(Mailbox::Mailbox0)
+                );
+                defmt::assert_eq!(
+                    m.lock(|state| state.can1.clear_request_completed_flag()),
+                    None
+                );
+                tx_fired.store(true, Ordering::Relaxed);
+            }
+        );
+        irq::scope(|scope| {
+            scope.register(interrupt::CAN1_TX, can1_tx);
+
+            defmt::assert!(!tx_fired.load(Ordering::Relaxed));
+            let frame = Frame::new_data(StandardId::new(0).unwrap(), []);
+            defmt::assert!(m.lock(|state| state.roundtrip_frame(&frame)));
+            defmt::assert!(tx_fired.load(Ordering::Relaxed));
+        });
+
+        state
+            .can1
+            .disable_interrupt(Interrupt::TransmitMailboxEmpty);
+    }
+
+    #[test]
+    fn rx_interrupt_message_pending(state: &mut State) {
+        state.can1.enable_interrupt(Interrupt::Fifo0MessagePending);
+
+        let m = Mutex::new(&mut *state);
+        let interrupt_fired = AtomicBool::new(false);
+        handler!(
+            can1_rx = || {
+                defmt::debug!("interrupt: FIFO 0 message pending");
+                let frame = m.lock(|state| state.can1.receive().unwrap());
+                defmt::debug!("received {:?}", frame);
+
+                interrupt_fired.store(true, Ordering::Relaxed);
+            }
+        );
+        irq::scope(|scope| {
+            scope.register(interrupt::CAN1_RX0, can1_rx);
+
+            let frame = Frame::new_data(StandardId::new(0).unwrap(), []);
+            defmt::debug!("transmitting {:?}", frame);
+            defmt::assert!(!interrupt_fired.load(Ordering::Relaxed));
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+
+            m.lock(|state|
+                // Wait until the transmission has completed.
+                while !state.can1.is_transmitter_idle() {}
+            );
+
+            defmt::assert!(interrupt_fired.load(Ordering::Relaxed));
+        });
+
+        state.can1.disable_interrupt(Interrupt::Fifo0MessagePending);
+    }
+
+    #[test]
+    fn rx_interrupt_fifo_full(state: &mut State) {
+        state.can1.enable_interrupt(Interrupt::Fifo0Full);
+
+        let m = Mutex::new(&mut *state);
+        let interrupt_fired = AtomicBool::new(false);
+        handler!(
+            can1_rx = || {
+                defmt::debug!("interrupt: FIFO 0 is full");
+                let frame = m.lock(|state| state.can1.receive().unwrap());
+                defmt::debug!("received {:?}", frame);
+                let frame = m.lock(|state| state.can1.receive().unwrap());
+                defmt::debug!("received {:?}", frame);
+                let frame = m.lock(|state| state.can1.receive().unwrap());
+                defmt::debug!("received {:?}", frame);
+
+                interrupt_fired.store(true, Ordering::Relaxed);
+            }
+        );
+        irq::scope(|scope| {
+            scope.register(interrupt::CAN1_RX0, can1_rx);
+
+            let frame = Frame::new_data(StandardId::new(0).unwrap(), []);
+            defmt::debug!("transmitting {:?} 3 times", frame);
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+            defmt::assert!(!interrupt_fired.load(Ordering::Relaxed));
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+
+            m.lock(|state|
+                // Wait until all transmissions have completed.
+                while !state.can1.is_transmitter_idle() {}
+            );
+
+            defmt::assert!(interrupt_fired.load(Ordering::Relaxed));
+        });
+
+        state.can1.disable_interrupt(Interrupt::Fifo0Full);
+    }
+
+    #[test]
+    fn rx_interrupt_fifo_overrun(state: &mut State) {
+        state.can1.enable_interrupt(Interrupt::Fifo0Overrun);
+
+        let m = Mutex::new(&mut *state);
+        let interrupt_fired = AtomicBool::new(false);
+        handler!(
+            can1_rx = || {
+                defmt::debug!("interrupt: FIFO 0 overrun");
+                m.lock(|state| state.can1.receive().unwrap_err());
+
+                interrupt_fired.store(true, Ordering::Relaxed);
+            }
+        );
+        irq::scope(|scope| {
+            scope.register(interrupt::CAN1_RX0, can1_rx);
+
+            let frame = Frame::new_data(StandardId::new(0).unwrap(), []);
+            defmt::debug!("transmitting {:?} 4 times", frame);
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+
+            m.lock(|state|
+                // Wait until all transmissions have completed.
+                while !state.can1.is_transmitter_idle() {}
+            );
+
+            // FIFO should be full, but not have overrun.
+            defmt::assert!(!interrupt_fired.load(Ordering::Relaxed));
+
+            defmt::unwrap!(block!(m.lock(|state| state.can1.transmit(&frame))));
+
+            m.lock(|state|
+                // Wait until all transmissions have completed.
+                while !state.can1.is_transmitter_idle() {}
+            );
+
+            // Reception of the 4th message should have caused an overrun interrupt.
+            defmt::assert!(interrupt_fired.load(Ordering::Relaxed));
+        });
+
+        state.can1.disable_interrupt(Interrupt::Fifo0Overrun);
+    }
+
+    #[test]
+    fn sce_interrupt_sleep(state: &mut State) {
+        state.can1.enable_interrupts(Interrupts::SLEEP);
+
+        let m = Mutex::new(&mut *state);
+        let sleep_interrupt_fired = AtomicBool::new(false);
+        handler!(
+            on_sleep = || {
+                defmt::debug!("interrupt: entered sleep mode");
+                m.lock(|state| state.can1.clear_sleep_interrupt());
+                sleep_interrupt_fired.store(true, Ordering::Relaxed);
+            }
+        );
+        irq::scope(|scope| {
+            scope.register(interrupt::CAN1_SCE, on_sleep);
+
+            defmt::assert!(!sleep_interrupt_fired.load(Ordering::Relaxed));
+            m.lock(|state| state.can1.sleep());
+            defmt::assert!(sleep_interrupt_fired.load(Ordering::Relaxed));
+        });
+
+        state.can1.disable_interrupts(Interrupts::SLEEP);
+    }
+
+    #[test]
+    fn sce_interrupt_wakeup(state: &mut State) {
+        // The wakeup interrupt does not fire when calling `can.wakeup()`, it requires an incoming
+        // message. This test uses CAN2 to send that message.
+
+        state.can1.enable_interrupt(Interrupt::Wakeup);
+
+        // Turn off the loopback modes.
+        state
+            .can1
+            .modify_config()
+            .set_loopback(false)
+            .set_silent(false)
+            .set_bit_timing(0x00050000);
+        state
+            .can2
+            .modify_config()
+            .set_loopback(false)
+            .set_silent(false)
+            .set_bit_timing(0x00050000);
+        block!(state.can1.enable()).unwrap();
+        block!(state.can2.enable()).unwrap();
+
+        let m = Mutex::new(&mut *state);
+        let wakeup_interrupt_fired = AtomicBool::new(false);
+        handler!(
+            on_wakeup = || {
+                defmt::debug!("interrupt: left sleep mode");
+                m.lock(|state| state.can1.clear_wakeup_interrupt());
+                wakeup_interrupt_fired.store(true, Ordering::Relaxed);
+            }
+        );
+        irq::scope(|scope| {
+            scope.register(interrupt::CAN1_SCE, on_wakeup);
+
+            m.lock(|state| {
+                state.can1.set_automatic_wakeup(true);
+                state.can1.sleep();
+            });
+            let frame = Frame::new_data(StandardId::new(0).unwrap(), []);
+            defmt::unwrap!(block!(m.lock(|state| state.can2.transmit(&frame))));
+            m.lock(|state|
+                // Wait until all transmissions have completed.
+                while !state.can2.is_transmitter_idle() {}
+            );
+            defmt::assert!(wakeup_interrupt_fired.load(Ordering::Relaxed));
+        });
+
+        state.can1.disable_interrupt(Interrupt::Wakeup);
+        state.go_fast();
+    }
+}


### PR DESCRIPTION
This adds methods to acknowledge all interrupt sources (except error interrupts), improves the documentation around interrupts, and adds an HIL test suite for the interrupt functionality using [`irq`](https://docs.rs/irq). It also moves some testsuite functionality to a common place to allow easier reuse.