### PR TITLE
Make `defmt` support opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
     - name: Build
-      run: cargo build --all-targets
+      run: |
+        cargo build --all-targets
+        cargo build --all-targets --features unstable-defmt
     - name: Run tests
       run: cargo test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,16 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 bitflags = "1.2.1"
-defmt = "0.2.0"
 vcell = "0.1.2"
 nb = "1.0.0"
 embedded-can = "0.3"
+
+[dependencies.defmt]
+optional = true
+version = "0.2.0"
+
+[features]
+unstable-defmt = ["defmt"]
 
 [profile.test]
 opt-level = "s"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,7 +1,6 @@
 //! Filter bank API.
 
 use core::marker::PhantomData;
-use defmt::Format;
 
 use crate::pac::can::RegisterBlock;
 use crate::{ExtendedId, FilterOwner, Id, Instance, MasterInstance, StandardId};
@@ -9,24 +8,28 @@ use crate::{ExtendedId, FilterOwner, Id, Instance, MasterInstance, StandardId};
 /// A 16-bit filter list entry.
 ///
 /// This can match data and remote frames using standard IDs.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Format)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub struct ListEntry16(u16);
 
 /// A 32-bit filter list entry.
 ///
 /// This can match data and remote frames using extended or standard IDs.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Format)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub struct ListEntry32(u32);
 
 /// A 16-bit identifier mask.
-#[derive(Debug, Copy, Clone, Format)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub struct Mask16 {
     id: u16,
     mask: u16,
 }
 
 /// A 32-bit identifier mask.
-#[derive(Debug, Copy, Clone, Format)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub struct Mask32 {
     id: u32,
     mask: u32,
@@ -161,7 +164,8 @@ impl Mask32 {
 }
 
 /// The configuration of a filter bank.
-#[derive(Debug, Copy, Clone, Format)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub enum BankConfig {
     List16([ListEntry16; 4]),
     List32([ListEntry32; 2]),

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -3,12 +3,12 @@ mod tests;
 
 use core::cmp::Ordering;
 use core::ops::{Deref, DerefMut};
-use defmt::Format;
 
 use crate::{Id, IdReg};
 
 /// A CAN data or remote frame.
-#[derive(Clone, Debug, Eq, Format)]
+#[derive(Clone, Debug, Eq)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub struct Frame {
     pub(crate) id: IdReg,
     pub(crate) data: Data,
@@ -272,7 +272,8 @@ impl PartialEq for Data {
 
 impl Eq for Data {}
 
-impl Format for Data {
+#[cfg(feature = "unstable-defmt")]
+impl defmt::Format for Data {
     fn format(&self, fmt: defmt::Formatter<'_>) {
         self.as_ref().format(fmt)
     }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -2,8 +2,6 @@
 
 use core::ops;
 
-use defmt::Format;
-
 #[allow(unused_imports)] // for intra-doc links only
 use crate::{Can, Rx};
 
@@ -19,7 +17,8 @@ use crate::{Can, Rx};
 ///
 /// This means that some of the interrupts listed here will result in the same interrupt handler
 /// being invoked.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Format)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Interrupt {
     /// Fires the **TX** interrupt when one of the transmit mailboxes returns to empty state.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,16 @@
 //! - Currently, only RX FIFO 0 is supported, and FIFO 1 will not be used.
 //! - Support for querying error states and handling error interrupts is incomplete.
 //!
+//! # Cargo Features
+//!
+//! | Feature | Description |
+//! |---------|-------------|
+//! | `unstable-defmt` | Implements [`defmt`]'s `Format` trait for the types in this crate.[^1] |
+//!
+//! [^1]: The specific version of defmt is unspecified and may be updated in a patch release.
+//!
 //! [`embedded-can`]: https://docs.rs/embedded-can
+//! [`defmt`]: https://docs.rs/defmt
 
 #![doc(html_root_url = "https://docs.rs/bxcan/0.5.1")]
 // Deny a few warnings in doctests, since rustdoc `allow`s many warnings by default
@@ -43,7 +52,6 @@ use core::cmp::{Ord, Ordering};
 use core::convert::{Infallible, TryInto};
 use core::marker::PhantomData;
 use core::ptr::NonNull;
-use defmt::Format;
 
 use self::pac::generic::*; // To make the PAC extraction build
 
@@ -119,7 +127,8 @@ pub enum Error {
 /// Lower identifier values have a higher priority. Additionally standard frames
 /// have a higher priority than extended frames and data frames have a higher
 /// priority than remote frames.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Format)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 struct IdReg(u32);
 
 impl IdReg {
@@ -876,7 +885,8 @@ where
 }
 
 /// The three transmit mailboxes
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Format)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub enum Mailbox {
     /// Transmit mailbox 0
     Mailbox0 = 0,

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -18,7 +18,6 @@ name = "interrupts"
 harness = false
 
 [dependencies]
-bxcan = { path = ".." }
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.13"
 defmt = "0.2.0"
@@ -31,6 +30,10 @@ panic-probe = "0.2.0"
 stm32f1 = { version = "0.12.1", features = ["stm32f107", "rt"] }
 nb = "1.0.0"
 irq = "0.2.3"
+
+[dependencies.bxcan]
+path = ".."
+features = ["unstable-defmt"]
 
 [features]
 # set logging levels here


### PR DESCRIPTION
`defmt` is still evolving and making breaking changes, and it currently doesn't allow supporting multiple versions of it (https://github.com/knurling-rs/defmt/issues/426). By making it opt-in and leaving its version unspecified, it should not stand in the way of bxcan 1.0 anymore.