### PR TITLE
Make `CanConfig` harder to misuse

### DIFF
--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -112,13 +112,14 @@ impl State {
             .modify_config()
             .set_loopback(true)
             .set_silent(true)
-            .set_bit_timing(0x007f_03ff);
+            .set_bit_timing(0x007f_03ff)
+            .enable();
         self.can2
             .modify_config()
             .set_loopback(true)
             .set_silent(true)
-            .set_bit_timing(0x007f_03ff);
-        nb::block!(self.can1.enable()).unwrap();
+            .set_bit_timing(0x007f_03ff)
+            .enable();
     }
 
     /// Configures the default (fast) speed.
@@ -127,14 +128,14 @@ impl State {
             .modify_config()
             .set_loopback(true)
             .set_silent(true)
-            .set_bit_timing(0x00050000);
+            .set_bit_timing(0x00050000)
+            .enable();
         self.can2
             .modify_config()
             .set_loopback(true)
             .set_silent(true)
-            .set_bit_timing(0x00050000);
-        nb::block!(self.can1.enable()).unwrap();
-        nb::block!(self.can2.enable()).unwrap();
+            .set_bit_timing(0x00050000)
+            .enable();
     }
 
     pub fn roundtrip_frame(&mut self, frame: &Frame) -> bool {

--- a/testsuite/tests/integration.rs
+++ b/testsuite/tests/integration.rs
@@ -316,13 +316,15 @@ mod tests {
             .modify_config()
             .set_loopback(false)
             .set_silent(false)
-            .set_bit_timing(0x00050000);
+            .set_bit_timing(0x00050000)
+            .enable();
         state
             .can2
             .modify_config()
             .set_loopback(false)
             .set_silent(false)
-            .set_bit_timing(0x00050000);
+            .set_bit_timing(0x00050000)
+            .enable();
 
         state
             .can1
@@ -337,9 +339,6 @@ mod tests {
             .slave_filters()
             .clear()
             .enable_bank(1, Mask32::accept_all());
-
-        block!(state.can1.enable()).unwrap();
-        block!(state.can2.enable()).unwrap();
 
         let frame = Frame::new_data(ExtendedId::new(123).unwrap(), [9, 8, 7]);
         block!(state.can2.transmit(&frame)).unwrap();

--- a/testsuite/tests/integration.rs
+++ b/testsuite/tests/integration.rs
@@ -306,6 +306,16 @@ mod tests {
         state.go_fast();
     }
 
+    #[test]
+    fn enable_non_blocking(state: &mut State) {
+        drop(state.can1.modify_config());
+        block!(state.can1.enable_non_blocking()).unwrap();
+        defmt::assert!(state.can1.is_transmitter_idle());
+
+        let frame = Frame::new_data(StandardId::new(0).unwrap(), []);
+        defmt::assert!(state.roundtrip_frame(&frame));
+    }
+
     /// Performs an external roundtrip from CAN1 to CAN2 and vice-versa.
     ///
     /// Requires that both are hooked up to the same CAN bus.

--- a/testsuite/tests/interrupts.rs
+++ b/testsuite/tests/interrupts.rs
@@ -228,15 +228,15 @@ mod tests {
             .modify_config()
             .set_loopback(false)
             .set_silent(false)
-            .set_bit_timing(0x00050000);
+            .set_bit_timing(0x00050000)
+            .enable();
         state
             .can2
             .modify_config()
             .set_loopback(false)
             .set_silent(false)
-            .set_bit_timing(0x00050000);
-        block!(state.can1.enable()).unwrap();
-        block!(state.can2.enable()).unwrap();
+            .set_bit_timing(0x00050000)
+            .enable();
 
         let m = Mutex::new(&mut *state);
         let wakeup_interrupt_fired = AtomicBool::new(false);


### PR DESCRIPTION
Fixes https://github.com/stm32-rs/bxcan/issues/32

