### PR TITLE
Add configuration function to enable or disable automatic retransmit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-No changes.
+### New Features
+
+* Add `CanConfig::set_automatic_retransmit` function to enable or disable automatic frame retransmission ([#42]).
+
+[#42]: https://github.com/stm32-rs/bxcan/pull/42
 
 ## [0.5.1 - 2021-05-15](https://github.com/stm32-rs/bxcan/releases/tag/v0.5.1)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,11 +282,10 @@ impl<I: Instance> CanConfig<'_, I> {
     /// If this is enabled, the CAN peripheral will automatically try to retransmit each frame
     /// util it can be sent. Otherwise, it will only try once to send each frame.
     pub fn set_automatic_retransmit(&mut self, enabled: bool) -> &mut Self {
-        let can = self.registers();
+        let can = self.can.registers();
         can.mcr.modify(|_, w| w.nart().bit(!enabled));
         self
     }
-}
 
     /// Leaves initialization mode and enables the peripheral.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,16 @@ impl<I: Instance> CanConfig<'_, I> {
         can.btr.modify(|_, w| w.silm().bit(enabled));
         self
     }
+
+    /// Enables or disables automatic retransmission of messages
+    ///
+    /// If this is enabled, the CAN peripheral will automatically try to retransmit each frame
+    /// util it can be sent. Otherwise, it will only try once to send each frame.
+    pub fn set_automatic_retransmit(&mut self, enabled: bool) -> &mut Self {
+        let can = self.registers();
+        can.mcr.modify(|_, w| w.nart().bit(!enabled));
+        self
+    }
 }
 
 impl<I: Instance> Drop for CanConfig<'_, I> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl<I: Instance> CanConfig<'_, I> {
     /// Enables or disables automatic retransmission of messages
     ///
     /// If this is enabled, the CAN peripheral will automatically try to retransmit each frame
-    /// util it can be sent. Otherwise, it will only try once to send each frame.
+    /// util it can be sent. Otherwise, it will try only once to send each frame.
     pub fn set_automatic_retransmit(&mut self, enabled: bool) -> &mut Self {
         let can = self.can.registers();
         can.mcr.modify(|_, w| w.nart().bit(!enabled));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ impl<I: Instance> CanConfig<'_, I> {
     ///
     /// If this is enabled, the CAN peripheral will automatically try to retransmit each frame
     /// util it can be sent. Otherwise, it will try only once to send each frame.
-    pub fn set_automatic_retransmit(&mut self, enabled: bool) -> &mut Self {
+    pub fn set_automatic_retransmit(self, enabled: bool) -> Self {
         let can = self.can.registers();
         can.mcr.modify(|_, w| w.nart().bit(!enabled));
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,8 @@ impl<I: Instance> CanConfig<'_, I> {
     ///
     /// If this is enabled, the CAN peripheral will automatically try to retransmit each frame
     /// util it can be sent. Otherwise, it will try only once to send each frame.
+    ///
+    /// Automatic retransmission is enabled by default.
     pub fn set_automatic_retransmit(self, enabled: bool) -> Self {
         let can = self.can.registers();
         can.mcr.modify(|_, w| w.nart().bit(!enabled));


### PR DESCRIPTION
In some cases, we don't want the CAN peripheral to repeatedly try to transmit again each frame that cannot be transmitted.
With this pull request, I am proposing a small change that adds a function to `CanConfig` to enable or disable automatic retransmission using the NART bit.