### PR TITLE
Update defmt to 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ package = "embedded-can"
 
 [dependencies.defmt]
 optional = true
-version = "0.2.0"
+version = "0.2.3"
 
 [features]
 unstable-defmt = ["defmt"]


### PR DESCRIPTION
This upgrade is needed, as defmt `0.2.0` or `0.2.2`
in my case is depending on semver `0.11.0` which then
depends on pest_derive `1.0.0` which itself can not
build with it minimal choosen dependency version
for quote `0.3.0`

Upgrading defmt updgrades semver to `1.0.0`, which
itself does not depend on pest_derive anymore,
so that bxcan builds again.

This was all build under the dependecy resolution created
by:

    cargo +nightly update -Z minimal-versions