### PR TITLE
Add support for defmt 0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,10 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
     - name: Build
-      run: |
-        cargo build --all-targets
-        cargo build --all-targets --all-features
+      run: cargo build --all-targets
+    - name: Build All Features
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: cargo build --all-targets --all-features
     - name: Run tests
       run: cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Build
       run: cargo build --all-targets
     - name: Build All Features
+      # defmt 0.3 doesn't build when targeting windows
       if: ${{ matrix.os != 'windows-latest' }}
       run: cargo build --all-targets --all-features
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ package = "embedded-can"
 
 [dependencies.defmt]
 optional = true
-version = "0.2.3"
+version = ">=0.2.3,<0.4.0"
 
 [features]
 unstable-defmt = ["defmt"]

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -18,35 +18,19 @@ name = "interrupts"
 harness = false
 
 [dependencies]
-cortex-m = "0.6.3"
-cortex-m-rt = "0.6.13"
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
-defmt-test = "0.2.0"
-panic-probe = "0.2.0"
+cortex-m = "0.7.3"
+cortex-m-rt = "0.7.0"
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
+defmt-test = "0.3.0"
+panic-probe = "0.3.0"
 #panic-probe = { version = "0.2.0", features = ["print-defmt"] }
 # NB: We use F107 here, which seems to share its SVD file with the F105. The difference is that the
 # 107 has Ethernet, but we don't use that.
-stm32f1 = { version = "0.12.1", features = ["stm32f107", "rt"] }
+stm32f1 = { version = "0.14.0", features = ["stm32f107", "rt"] }
 nb = "1.0.0"
 irq = "0.2.3"
 
 [dependencies.bxcan]
 path = ".."
 features = ["unstable-defmt"]
-
-[features]
-# set logging levels here
-default = [
-  # in tests, enable all logs
-  "defmt-trace",
-  # "dependency-a/defmt-trace",
-]
-
-# do NOT modify these features
-defmt-default = []
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []


### PR DESCRIPTION
Update defmt (and other knurling-rs tools) to 0.3, see <https://ferrous-systems.com/blog/defmt-3/>