### PR TITLE
Update defmt and stm32f1 and cortex-m dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ package = "embedded-can"
 
 [dependencies.defmt]
 optional = true
-version = "0.2.3"
+version = "0.3"
 
 [features]
 unstable-defmt = ["defmt"]

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -18,16 +18,16 @@ name = "interrupts"
 harness = false
 
 [dependencies]
-cortex-m = "0.6.3"
-cortex-m-rt = "0.6.13"
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
-defmt-test = "0.2.0"
-panic-probe = "0.2.0"
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+defmt = "0.3"
+defmt-rtt = "0.3"
+defmt-test = "0.3"
+panic-probe = "0.3"
 #panic-probe = { version = "0.2.0", features = ["print-defmt"] }
 # NB: We use F107 here, which seems to share its SVD file with the F105. The difference is that the
 # 107 has Ethernet, but we don't use that.
-stm32f1 = { version = "0.12.1", features = ["stm32f107", "rt"] }
+stm32f1 = { version = "0.14", features = ["stm32f107", "rt"] }
 nb = "1.0.0"
 irq = "0.2.3"
 


### PR DESCRIPTION
Hiya--

Trying to get embassy using a newer (patched) probe-run which requires newer defmt, which requires things we rely upon to also use the same version of defmt, and thus, here I am.