### PR TITLE
Fix license mismatch in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/stm32-rs/bxcan.git"
 keywords = ["can", "hal", "bus"]
 categories = ["no-std", "embedded"]
 readme = "README.md"
-license = "0BSD"
+license = "MIT OR Apache-2.0"
 
 [workspace]
 members = ["testsuite"]


### PR DESCRIPTION
I've noticed, that the license in the `Cargo.toml` does not match the license files included in the repository (`LICENSE-MIT` / `LICENSE-APACHE`). 