### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,9 +266,9 @@ impl<I: Instance> CanConfig<'_, I> {
     /// parameter to this method.
     pub fn set_bit_timing(self, btr: u32) -> Self {
         let can = self.can.registers();
-        can.btr.modify(|r, w| unsafe {
+        can.btr.modify(|r, w| {
             let mode_bits = r.bits() & 0xC000_0000;
-            w.bits(mode_bits | btr)
+            unsafe { w.bits(mode_bits | btr) }
         });
         self
     }
@@ -369,9 +369,9 @@ impl<I: Instance> CanBuilder<I> {
     /// parameter to this method.
     pub fn set_bit_timing(self, btr: u32) -> Self {
         let can = self.can.registers();
-        can.btr.modify(|r, w| unsafe {
+        can.btr.modify(|r, w| {
             let mode_bits = r.bits() & 0xC000_0000;
-            w.bits(mode_bits | btr)
+            unsafe { w.bits(mode_bits | btr) }
         });
         self
     }


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 


Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 