### PR TITLE
Add unchecked unsafe function to create data for frame

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -179,6 +179,15 @@ impl Data {
         })
     }
 
+    /// Creates an unchecked data from payload and size
+    #[inline]
+    pub const unsafe fn new_unchecked(len: u8, bytes: [u8; 8]) -> Self {
+        Self {
+            len,
+            bytes
+        }
+    }
+
     /// Creates an empty data payload containing 0 bytes.
     #[inline]
     pub const fn empty() -> Self {


### PR DESCRIPTION
This addition allows the creation of Data without using slices.
It's useful when you already have the len and the [u8; 8].