### PR TITLE
Update embedded hal traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Mask out all reserved bits in `set_bit_timing` before writing the register.
 
+### Other Changes
+
+* Update the embedded hal dependency to use the new embedded-can crate instead.
+
 ## [0.7.0 - 2022-05-30](https://github.com/stm32-rs/bxcan/releases/tag/v0.7.0)
 
 ### New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ bitflags = "1.2.1"
 vcell = "0.1.2"
 nb = "1.0.0"
 
-[dependencies.embedded-hal-02]
-version = "0.2.7"
-package = "embedded-hal"
+[dependencies.embedded-can-04]
+version = "0.4.1"
+package = "embedded-can"
 
 [dependencies.defmt]
 optional = true

--- a/src/embedded_hal.rs
+++ b/src/embedded_hal.rs
@@ -2,9 +2,9 @@
 
 use crate::{Can, Data, ExtendedId, Frame, Id, Instance, OverrunError, StandardId};
 
-use embedded_hal_02::can;
+use embedded_can_04 as can;
 
-impl<I> can::Can for Can<I>
+impl<I> can::nb::Can for Can<I>
 where
     I: Instance,
 {

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -21,7 +21,7 @@ harness = false
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
 defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+defmt-rtt = "0.4.0"
 defmt-test = "0.3.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 # NB: We use F107 here, which seems to share its SVD file with the F105. The difference is that the

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -18,7 +18,7 @@ name = "interrupts"
 harness = false
 
 [dependencies]
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.3", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 defmt = "0.3.0"
 defmt-rtt = "0.4.0"


### PR DESCRIPTION
This PR updates the `embedded-hal` dependency and switches to its replacement `embedded-can`. This means that now `socketcan` and `bxcan` share a common trait in the `embedded-can` library, which me really would like.