### PR TITLE
Upgraded the embedded-hal crate to embedded-can

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,8 @@ maintenance = { status = "actively-developed" }
 bitflags = "1.2.1"
 vcell = "0.1.2"
 nb = "1.0.0"
+embedded-can = "0.4.1"
 
-[dependencies.embedded-hal-02]
-version = "0.2.7"
-package = "embedded-hal"
 
 [dependencies.defmt]
 optional = true

--- a/src/embedded_hal.rs
+++ b/src/embedded_hal.rs
@@ -2,9 +2,9 @@
 
 use crate::{Can, Data, ExtendedId, Frame, Id, Instance, OverrunError, StandardId};
 
-use embedded_hal_02::can;
+use embedded_can as can;
 
-impl<I> can::Can for Can<I>
+impl<I> can::nb::Can for Can<I>
 where
     I: Instance,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub use crate::pac::can::RegisterBlock;
 
 use crate::filter::MasterFilters;
 use core::cmp::{Ord, Ordering};
-use core::convert::{Infallible, TryInto};
+use core::convert::Infallible;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr::NonNull;


### PR DESCRIPTION
They've done a little bit of shuffling around on the embedded hal arena.  This is to keep things is sync as it should remain stable for a while now.