### PR TITLE
Add support for the error status register and error interrupts

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -64,6 +64,47 @@ pub enum Interrupt {
     /// Behavior is otherwise identical to [`Self::Fifo0Overrun`].
     Fifo1Overrun = 1 << 6,
 
+    /// Fires the **SCE** interrupt when the error warning limit (receive or transmit error counter
+    /// >= 96) has been reached.
+    /// 
+    /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
+    /// 
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_error_interrupt`].
+    ErrorWarning = 1 << 8,
+
+    /// Fires the **SCE** interrupt when the peripheral enters the error passive state.
+    /// 
+    /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
+    /// 
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_error_interrupt`].
+    ErrorPassive = 1 << 9,
+
+    /// Fires the **SCE** interrupt when the peripheral has entered bus-off.
+    /// 
+    /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
+    /// 
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_error_interrupt`].
+    BusOff = 1 << 10,
+
+    /// Fires the **SCE** interrupt when the peripheral updates the last error code.
+    /// 
+    /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
+    /// 
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_error_interrupt`].
+    LastErrorCode = 1 << 11,
+
+    /// Fires the **SCE** interrupt when the peripheral enters an error state.
+    /// 
+    /// The error states that will cause the interrupt to fire are determined by the subset of
+    /// [`Interrupt::ErrorWarning`], [`Interrupt::ErrorPassive`], [`Interrupt::BusOff`], and 
+    /// [`Interrupt::LastErrorCode`] that are enabled along with this flag.
+    ///
+    /// The interrupt handler must clear the interrupt condition by calling
+    /// [`Can::clear_error_interrupt`].
     Error = 1 << 15,
 
     /// Fires the **SCE** interrupt when an incoming CAN frame is detected while the peripheral is
@@ -90,6 +131,10 @@ bitflags::bitflags! {
         const FIFO1_MESSAGE_PENDING = 1 << 4;
         const FIFO1_FULL = 1 << 5;
         const FIFO1_OVERRUN = 1 << 6;
+        const ERROR_WARNING = 1 << 8;
+        const ERROR_PASSIVE = 1 << 9;
+        const BUS_OFF = 1 << 10;
+        const LAST_ERROR_CODE = 1 << 11;
         const ERROR = 1 << 15;
         const WAKEUP = 1 << 16;
         const SLEEP = 1 << 17;

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -66,41 +66,41 @@ pub enum Interrupt {
 
     /// Fires the **SCE** interrupt when the error warning limit (receive or transmit error counter
     /// >= 96) has been reached.
-    /// 
+    ///
     /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
-    /// 
+    ///
     /// The interrupt handler must clear the interrupt condition by calling
     /// [`Can::clear_error_interrupt`].
     ErrorWarning = 1 << 8,
 
     /// Fires the **SCE** interrupt when the peripheral enters the error passive state.
-    /// 
+    ///
     /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
-    /// 
+    ///
     /// The interrupt handler must clear the interrupt condition by calling
     /// [`Can::clear_error_interrupt`].
     ErrorPassive = 1 << 9,
 
     /// Fires the **SCE** interrupt when the peripheral has entered bus-off.
-    /// 
+    ///
     /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
-    /// 
+    ///
     /// The interrupt handler must clear the interrupt condition by calling
     /// [`Can::clear_error_interrupt`].
     BusOff = 1 << 10,
 
     /// Fires the **SCE** interrupt when the peripheral updates the last error code.
-    /// 
+    ///
     /// [`Interrupt::Error`] must also be enabled for the interrupt to fire.
-    /// 
+    ///
     /// The interrupt handler must clear the interrupt condition by calling
     /// [`Can::clear_error_interrupt`].
     LastErrorCode = 1 << 11,
 
     /// Fires the **SCE** interrupt when the peripheral enters an error state.
-    /// 
+    ///
     /// The error states that will cause the interrupt to fire are determined by the subset of
-    /// [`Interrupt::ErrorWarning`], [`Interrupt::ErrorPassive`], [`Interrupt::BusOff`], and 
+    /// [`Interrupt::ErrorWarning`], [`Interrupt::ErrorPassive`], [`Interrupt::BusOff`], and
     /// [`Interrupt::LastErrorCode`] that are enabled along with this flag.
     ///
     /// The interrupt handler must clear the interrupt condition by calling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,9 +709,17 @@ where
     /// This will return an [`ErrorStatus`] containing information on the error.
     pub fn clear_error_interrupt(&mut self) -> ErrorStatus {
         let can = self.registers();
+        let stat = self.error_status();
+        can.msr.write(|w| w.erri().set_bit());
+        stat
+    }
+
+    /// Reads the error status register's data as an [`ErrorStatus`].
+    pub fn error_status(&self) -> ErrorStatus {
+        let can = self.registers();
         let esr = can.esr.read();
 
-        let stat = ErrorStatus {
+        ErrorStatus {
             recv_count: esr.rec().bits,
             txmt_count: esr.tec().bits,
             code: (match esr.lec().bits {
@@ -728,9 +736,7 @@ where
             bus_off: esr.boff().bits,
             err_passive: esr.epvf().bits,
             err_warning: esr.ewgf().bits
-        };
-        can.msr.write(|w| w.erri().set_bit());
-        stat
+        }
     }
 
     /// Puts a CAN frame in a free transmit mailbox for transmission on the bus.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ impl ErrorStatus {
     }
 
     /// Returns true if the peripheral is currently in bus-off.
-    /// 
+    ///
     /// This occurs when the transmit error counter overflows past 255.
     #[inline]
     pub fn bus_off(&self) -> bool {
@@ -163,7 +163,7 @@ impl ErrorStatus {
     }
 
     /// Returns true if the error passive limit has been reached.
-    /// 
+    ///
     /// This occurs when the receive or transmit error counters exceed 127.
     #[inline]
     pub fn error_passive(&self) -> bool {
@@ -171,14 +171,13 @@ impl ErrorStatus {
     }
 
     /// Returns true if the error warning limit has been reached.
-    /// 
+    ///
     /// This occurs when the receive or transmit error counters are greater than or equal 96.
     #[inline]
     pub fn error_warning(&self) -> bool {
         self.err_warning
     }
 }
-
 
 /// Error that indicates that an incoming message has been lost due to buffer overrun.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -709,7 +708,7 @@ where
     }
 
     /// Clears the error interrupt flag ([`Interrupt::Error`]).
-    /// 
+    ///
     /// To read the error status, use [`Can::error_status`] to get the [`ErrorStatus`] before
     /// clearing the interrupt flag.
     pub fn clear_error_interrupt(&mut self) {
@@ -740,7 +739,7 @@ where
             }),
             bus_off: esr.boff().bits,
             err_passive: esr.epvf().bits,
-            err_warning: esr.ewgf().bits
+            err_warning: esr.ewgf().bits,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub unsafe trait MasterInstance: FilterOwner {}
 /// Enum of error status codes from the error status register.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
-pub enum Error{
+pub enum Error {
     None,
     Stuff,
     Form,
@@ -124,8 +124,6 @@ pub enum Error{
 }
 
 /// The peripheral's current error status.
-/// 
-/// This is returned when clearing an error status interrupt.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "unstable-defmt", derive(defmt::Format))]
 pub struct ErrorStatus {
@@ -157,18 +155,24 @@ impl ErrorStatus {
     }
 
     /// Returns true if the peripheral is currently in bus-off.
+    /// 
+    /// This occurs when the transmit error counter overflows past 255.
     #[inline]
     pub fn bus_off(&self) -> bool {
         self.bus_off
     }
 
     /// Returns true if the error passive limit has been reached.
+    /// 
+    /// This occurs when the receive or transmit error counters exceed 127.
     #[inline]
     pub fn error_passive(&self) -> bool {
         self.err_passive
     }
 
     /// Returns true if the error warning limit has been reached.
+    /// 
+    /// This occurs when the receive or transmit error counters are greater than or equal 96.
     #[inline]
     pub fn error_warning(&self) -> bool {
         self.err_warning
@@ -706,15 +710,16 @@ where
 
     /// Clears the error interrupt flag ([`Interrupt::Error`]).
     /// 
-    /// This will return an [`ErrorStatus`] containing information on the error.
-    pub fn clear_error_interrupt(&mut self) -> ErrorStatus {
+    /// To read the error status, use [`Can::error_status`] to get the [`ErrorStatus`] before
+    /// clearing the interrupt flag.
+    pub fn clear_error_interrupt(&mut self) {
         let can = self.registers();
-        let stat = self.error_status();
         can.msr.write(|w| w.erri().set_bit());
-        stat
     }
 
-    /// Reads the error status register's data as an [`ErrorStatus`].
+    /// Reads the error status register's data.
+    ///
+    /// This does not clear the error interrupt flag.
     pub fn error_status(&self) -> ErrorStatus {
         let can = self.registers();
         let esr = can.esr.read();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,6 @@
 //! - Implements the [`embedded-hal`] traits for interoperability.
 //! - Support for both RX FIFOs (as [`Rx0`] and [`Rx1`]).
 //!
-//! # Limitations
-//!
-//! - Support for querying error states and handling error interrupts is incomplete.
-//!
 //! # Cargo Features
 //!
 //! | Feature | Description |


### PR DESCRIPTION
This allows for handling error interrupts in SCE as well as reading the error status register's data as a nice struct.